### PR TITLE
Update aws-ec2.json

### DIFF
--- a/aws-ec2/aws-ec2.json
+++ b/aws-ec2/aws-ec2.json
@@ -1117,7 +1117,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1148,7 +1148,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1263,7 +1263,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1294,7 +1294,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1414,7 +1414,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1534,7 +1534,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1565,7 +1565,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1596,7 +1596,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1720,7 +1720,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1751,7 +1751,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {
@@ -1875,7 +1875,7 @@
             "filter": ""
           },
           "dimensions": {
-            "VolumeId": "$volumeid"
+            "VolumeId": "*"
           },
           "functions": [],
           "group": {


### PR DESCRIPTION
added wildcard to `$volumeid` variable due to error when using cloudwatch datasource and AWS EC2 dashboard from the Grafana Dashboard Marketplace using `id 617 rev 4`.

issue with variable `$volumeid`:
```
Templating [volumeid]
Error updating options: JSON.parse: unexpected character at line 1 column 1 of the JSON data

JSON.parse: unexpected character at line 1 column 1 of the JSON data
```

The below query of the variable throws above error:
```
ebs_volume_ids($region, $instanceid)
```